### PR TITLE
Add `algorithms` parameter to restrict JWT algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ const server = new flora.Server('./config.js');
 
 server.register('auth-jwt', floraAuthJwt, {
     secret: 'My Secret Key',
+    algorithms: ['HS256'], // optional
     credentialsRequired: false, // default: true
     validate: async (jwt, request) => {
         // return value will go to request._auth


### PR DESCRIPTION
Currently, all algorithms are allowed (if a secret is given, the `jsonwebtoken` library rejects `none`)